### PR TITLE
ptuxchange: use rev-parse to check for git

### DIFF
--- a/ptuxchange
+++ b/ptuxchange
@@ -51,7 +51,8 @@ create_placeholder () {
 }
 
 release_changelog () {
-	if [ -d .git ]; then
+    if [ -d .git ] || git rev-parse --git-dir > /dev/null
+	then
 		git update-index --assume-unchanged debian/changelog
 	fi
 


### PR DESCRIPTION
Checking only for a .git directory in the working directory means
that we have to run ptuxbuild from the topmost directory of the
repository. Not all projects are structured that way.

If the check for .git fails, we try git rev-parse --git-dir
before we declare that we're not in a git-controlled directory.
This lets us confirm from any subdirectory of the project.

Signed-off-by: Bill Gatliff <bgat@billgatliff.com>